### PR TITLE
Fixes #3 added dereference flag to tarfile.open, to follow symlinks

### DIFF
--- a/keeper.py
+++ b/keeper.py
@@ -119,7 +119,7 @@ class Keeper:
             self.bar = Bar('Processing', max=self.count)
 
         # Create tar file and save all directories to it
-        with tarfile.open(file_path, 'w:gz') as archive:
+        with tarfile.open(file_path, mode='w:gz', dereference=True) as archive:
             for directory in self.system_directories:
                 logging.info("adding directory {}".format(directory))
                 archive.add(directory)


### PR DESCRIPTION
Perhaps it covers an edge case, but there shouldn't be an adverse effect for Python versions newer than  2.4